### PR TITLE
refactor(role): 将RolePlatformAdmin统一重命名为RoleAdmin

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func main() {
 	r.Use(cors.Default())
 	r.Use(gzip.Gzip(gzip.BestCompression))
 	r.Use(middleware.SetCacheHeaders())
-	r.Use(middleware.AuthMiddleware())
+	r.Use(middleware.RequireLogin())
 
 	r.MaxMultipartMemory = 100 << 20 // 100 MiB
 
@@ -161,7 +161,7 @@ func main() {
 	}
 
 	// 公共参数
-	params := r.Group("/params", middleware.AuthMiddleware())
+	params := r.Group("/params", middleware.RequireLogin())
 	{
 		// 获取当前登录用户的角色，登录即可
 		params.GET("/user/role", param.UserRole)
@@ -171,7 +171,7 @@ func main() {
 		params.GET("/version", param.Version)
 
 	}
-	ai := r.Group("/ai", middleware.AuthMiddleware())
+	ai := r.Group("/ai", middleware.RequireLogin())
 	{
 
 		// chatgpt
@@ -182,7 +182,7 @@ func main() {
 
 	}
 
-	mgm := r.Group("/mgm", middleware.AuthMiddleware())
+	mgm := r.Group("/mgm", middleware.RequireLogin())
 	{
 
 		// user profile 用户自助操作

--- a/pkg/comm/utils/amis/gin.go
+++ b/pkg/comm/utils/amis/gin.go
@@ -25,11 +25,11 @@ func GetLoginUser(c *gin.Context) (string, string) {
 	role := c.GetString(constants.JwtUserRole)
 
 	roles := strings.Split(role, ",")
-	role = constants.RoleGuest
+	role = constants.RoleUser
 
 	// 检查是否平台管理员
-	if slice.Contain(roles, constants.RolePlatformAdmin) {
-		role = constants.RolePlatformAdmin
+	if slice.Contain(roles, constants.RoleAdmin) {
+		role = constants.RoleAdmin
 	}
 	return user, role
 }
@@ -41,11 +41,11 @@ func GetLoginUserWithClusterRoles(c *gin.Context) (string, string) {
 	role := c.GetString(constants.JwtUserRole)
 
 	roles := strings.Split(role, ",")
-	role = constants.RoleGuest
+	role = constants.RoleUser
 
 	// 检查是否平台管理员
-	if slice.Contain(roles, constants.RolePlatformAdmin) {
-		role = constants.RolePlatformAdmin
+	if slice.Contain(roles, constants.RoleAdmin) {
+		role = constants.RoleAdmin
 	}
 
 	return user, role
@@ -56,7 +56,7 @@ func GetLoginUserWithClusterRoles(c *gin.Context) (string, string) {
 func IsCurrentUserPlatformAdmin(c *gin.Context) bool {
 	role := c.GetString(constants.JwtUserRole)
 	roles := strings.Split(role, ",")
-	return slice.Contain(roles, constants.RolePlatformAdmin)
+	return slice.Contain(roles, constants.RoleAdmin)
 }
 
 func GetContextWithUser(c *gin.Context) context.Context {

--- a/pkg/comm/utils/platform.go
+++ b/pkg/comm/utils/platform.go
@@ -8,5 +8,5 @@ import (
 
 // GetContextWithAdmin 返回一个包含平台管理员角色信息的新上下文对象。
 func GetContextWithAdmin() context.Context {
-	return context.WithValue(context.Background(), constants.RolePlatformAdmin, constants.RolePlatformAdmin)
+	return context.WithValue(context.Background(), constants.RoleAdmin, constants.RoleAdmin)
 }

--- a/pkg/constants/role.go
+++ b/pkg/constants/role.go
@@ -1,23 +1,8 @@
 package constants
 
-//	用户角色两种，平台管理员、普通用户
-//
-// 平台管理员拥有所有权限
-// 普通用户需要赋予集群角色，
-// 集群角色三种，集群管理员、集群只读、集群Pod内执行命令
+// 用户角色两种，平台管理员、普通用户
 const (
-	RolePlatformAdmin = "platform_admin" // 平台管理员
-	RoleGuest         = "guest"          // 普通用户，只能登录，约等于游客,无任何集群权限，也看不到集群列表
-
-	RoleClusterAdmin    = "cluster_admin"    // 集群管理员
-	RoleClusterReadonly = "cluster_readonly" // 集群只读权限
-	RoleClusterPodExec  = "cluster_pod_exec" // 集群Pod内执行命令权限
-)
-
-// ClusterAuthorizationType 集群授权类型
-type ClusterAuthorizationType string
-
-const (
-	ClusterAuthorizationTypeUser      ClusterAuthorizationType = "user"
-	ClusterAuthorizationTypeUserGroup ClusterAuthorizationType = "user_group"
+	RoleAdmin = "admin" // 平台管理员
+	RoleUser  = "user"  // 普通用户
+	RoleGuest = "guest" // 游客，未登录、无权限
 )

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -11,8 +11,8 @@ import (
 	"github.com/weibaohui/openDeepWiki/pkg/flag"
 )
 
-// AuthMiddleware 登录校验
-func AuthMiddleware() gin.HandlerFunc {
+// RequireLogin 登录校验
+func RequireLogin() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// 获取请求路径
 		path := c.Request.URL.Path
@@ -58,7 +58,7 @@ func PlatformAuthMiddleware() gin.HandlerFunc {
 
 		// 权限检查
 		roles := strings.Split(role, ",")
-		if !slices.Contains(roles, constants.RolePlatformAdmin) {
+		if !slices.Contains(roles, constants.RoleAdmin) {
 			c.JSON(http.StatusForbidden, gin.H{"error": "平台管理员权限校验失败"})
 			c.Abort()
 			return

--- a/pkg/middleware/permission.go
+++ b/pkg/middleware/permission.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"net/http"
-	"reflect"
 	"slices"
 	"strings"
 
@@ -10,33 +9,6 @@ import (
 	"github.com/weibaohui/openDeepWiki/pkg/comm/utils/amis"
 	"github.com/weibaohui/openDeepWiki/pkg/constants"
 )
-
-func RolePlatformOnly(handler interface{}) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		_, role := amis.GetLoginUser(c)
-		if role == "" {
-			role = "guest"
-		}
-
-		// 通过反射获取方法名
-		handlerValue := reflect.ValueOf(handler)
-		// handlerType := handlerValue.Type()
-
-		// 获取 struct tag
-		// requiredRole := handlerType.Name()
-
-		// 权限检查
-		roles := strings.Split(role, ",")
-		if !slices.Contains(roles, constants.RolePlatformAdmin) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "Access Denied for your role"})
-			c.Abort()
-			return
-		}
-
-		// 继续执行请求处理
-		handlerValue.Call([]reflect.Value{reflect.ValueOf(c)})
-	}
-}
 
 // RequireAdmin 检查用户是否为管理员的中间件
 func RequireAdmin() gin.HandlerFunc {
@@ -47,7 +19,7 @@ func RequireAdmin() gin.HandlerFunc {
 		}
 
 		roles := strings.Split(role, ",")
-		if !slices.Contains(roles, constants.RolePlatformAdmin) {
+		if !slices.Contains(roles, constants.RoleAdmin) {
 			c.JSON(http.StatusForbidden, gin.H{"error": "需要管理员权限"})
 			c.Abort()
 			return

--- a/pkg/service/user.go
+++ b/pkg/service/user.go
@@ -132,7 +132,7 @@ func (u *userService) CheckAndCreateUser(username, source string) error {
 func (u *userService) GetPlatformRolesByName(username string) string {
 	cfg := flag.Init()
 	if cfg.EnableTempAdmin && username == cfg.AdminUserName {
-		return constants.RolePlatformAdmin
+		return constants.RoleAdmin
 	}
 	if names, err := u.GetGroupNames(username); err == nil {
 		if rolesByGroupNames, err := u.GetRolesByGroupNames(names); err == nil {


### PR DESCRIPTION
简化角色命名，统一使用RoleAdmin代替RolePlatformAdmin，提高代码一致性和可读性。删除不必要的角色定义和中间件方法，减少冗余代码。