### PR TITLE
refactor: 统一用户角色和组命名

### DIFF
--- a/pkg/constants/jwt_user.go
+++ b/pkg/constants/jwt_user.go
@@ -2,5 +2,5 @@ package constants
 
 const (
 	JwtUserName = "username"
-	JwtUserRole = "role" // todo 改为复数
+	JwtUserRole = "role"
 )

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"net/http"
-	"slices"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -34,33 +33,6 @@ func RequireLogin() gin.HandlerFunc {
 			c.JSON(http.StatusUnauthorized, gin.H{"message": err.Error()})
 			c.Abort()
 
-			return
-		}
-
-		// 设置信息传递，后面才能从ctx中获取到用户信息
-		c.Set(constants.JwtUserName, claims[constants.JwtUserName])
-		c.Set(constants.JwtUserRole, claims[constants.JwtUserRole])
-		c.Next()
-	}
-}
-
-// PlatformAuthMiddleware 平台管理员角色校验
-func PlatformAuthMiddleware() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		cfg := flag.Init()
-		claims, err := utils.GetJWTClaims(c, cfg.JwtTokenSecret)
-		if err != nil {
-			c.JSON(http.StatusUnauthorized, gin.H{"message": err.Error()})
-			c.Abort()
-			return
-		}
-		role := claims[constants.JwtUserRole].(string)
-
-		// 权限检查
-		roles := strings.Split(role, ",")
-		if !slices.Contains(roles, constants.RoleAdmin) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "平台管理员权限校验失败"})
-			c.Abort()
 			return
 		}
 

--- a/pkg/models/migrate.go
+++ b/pkg/models/migrate.go
@@ -105,16 +105,16 @@ func AddInnerAdminUser() error {
 	if count == 0 {
 		config := &User{
 			Username:   "admin",
-			Salt:       "grfi92rq",
-			Password:   "8RGCXWw6IzgKDPyeFKt6Kw==",
-			GroupNames: "平台管理员组",
+			Salt:       "oi09q0ng",
+			Password:   "gw0rZUYbEqZ4U8S5Jse3Lw==",
+			GroupNames: "管理员组",
 			CreatedBy:  "system",
 		}
 		if err := dao.DB().Create(config).Error; err != nil {
-			klog.Errorf("添加默认平台管理员账户失败: %v", err)
+			klog.Errorf("添加默认管理员账户失败: %v", err)
 			return err
 		}
-		klog.V(4).Info("成功添加默认平台管理员账户")
+		klog.V(4).Info("成功添加默认管理员账户")
 	} else {
 		klog.V(4).Info("默认平台管理员admin账户已存在")
 	}
@@ -126,24 +126,24 @@ func AddInnerAdminUser() error {
 func AddInnerAdminUserGroup() error {
 	// 检查是否存在名为 平台管理员组 的内置管理员账户组的记录
 	var count int64
-	if err := dao.DB().Model(&UserGroup{}).Where("group_name = ?", "平台管理员组").Count(&count).Error; err != nil {
-		klog.Errorf("已存在内置 平台管理员组 角色: %v", err)
+	if err := dao.DB().Model(&UserGroup{}).Where("group_name = ?", "管理员组").Count(&count).Error; err != nil {
+		klog.Errorf("已存在内置 管理员组 角色: %v", err)
 		return err
 	}
 	// 如果不存在，添加默认的内部MCP服务器配置
 	if count == 0 {
 		config := &UserGroup{
-			GroupName: "平台管理员组",
-			Role:      "platform_admin",
+			GroupName: "管理员组",
+			Role:      "admin",
 			CreatedBy: "system",
 		}
 		if err := dao.DB().Create(config).Error; err != nil {
-			klog.Errorf("添加默认平台管理员组失败: %v", err)
+			klog.Errorf("添加默认管理员组失败: %v", err)
 			return err
 		}
-		klog.V(4).Info("成功添加默认平台管理员组")
+		klog.V(4).Info("成功添加默认管理员组")
 	} else {
-		klog.V(4).Info("默认平台管理员组已存在")
+		klog.V(4).Info("默认管理员组已存在")
 	}
 
 	return nil

--- a/ui/public/pages/admin/user/user_group.json
+++ b/ui/public/pages/admin/user/user_group.json
@@ -44,11 +44,11 @@
                   "options": [
                     {
                       "label": "普通用户",
-                      "value": "guest"
+                      "value": "user"
                     },
                     {
                       "label": "平台管理员",
-                      "value": "platform_admin"
+                      "value": "admin"
                     }
                   ],
                   "placeholder": "请选择角色"
@@ -58,17 +58,8 @@
                   "name": "description",
                   "label": "描述",
                   "placeholder": "请输入用户组描述"
-                },
-                {
-                  "type": "alert",
-                  "level": "success",
-                  "body": "<div class='alert alert-info'><p><strong>普通用户：</strong>无集群权限，除非在集群中进行显式授权。</p><p><strong>平台管理员：</strong>可以管理平台配置、用户权限等系统级设置。</p></div>"
-                },
-                {
-                  "type": "alert",
-                  "level": "success",
-                  "body": "<div class='alert alert-info'><p><strong>普通用户需要授权，不授权看不到任何集群。授权规则如下：</strong></p><p><strong>集群管理员：</strong>可以管理和操作所有集群资源，包括创建、修改、删除等操作。</p><p><strong>集群只读：</strong>仅可查看集群资源信息，无法进行修改操作。</p><p><strong>Exec权限：</strong>具有进入容器内，执行命令的权限</p></div>"
                 }
+
               ],
               "submitText": "保存",
               "onEvent": {
@@ -124,11 +115,11 @@
                       "options": [
                         {
                           "label": "普通用户",
-                          "value": "guest"
+                          "value": "user"
                         },
                         {
-                          "label": "平台管理员",
-                          "value": "platform_admin"
+                          "label": "管理员",
+                          "value": "admin"
                         }
                       ],
                       "placeholder": "请选择角色"
@@ -137,17 +128,8 @@
                       "type": "textarea",
                       "name": "description",
                       "label": "描述"
-                    },
-                    {
-                      "type": "alert",
-                      "level": "success",
-                      "body": "<div class='alert alert-info'><p><strong>普通用户：</strong>无集群权限，除非在集群中进行显式授权。</p><p><strong>平台管理员：</strong>可以管理平台配置、用户权限等系统级设置。</p></div>"
-                    },
-                    {
-                      "type": "alert",
-                      "level": "success",
-                      "body": "<div class='alert alert-info'><p><strong>普通用户需要授权，不授权看不到任何集群。授权规则如下：</strong></p><p><strong>集群管理员：</strong>可以管理和操作所有集群资源，包括创建、修改、删除等操作。</p><p><strong>集群只读：</strong>仅可查看集群资源信息，无法进行修改操作。</p><p><strong>Exec权限：</strong>具有进入容器内，执行命令的权限</p></div>"
                     }
+
                   ]
                 }
               }
@@ -175,8 +157,8 @@
           "label": "角色",
           "type": "mapping",
           "map": {
-            "guest": "普通用户",
-            "platform_admin": "平台管理员"
+            "user": "普通用户",
+            "admin": "管理员"
           },
           "searchable": {
             "type": "select",
@@ -186,16 +168,13 @@
             "placeholder": "请选择角色",
             "options": [
               {
-                "label": "集群管理员",
-                "value": "cluster_admin"
+                "label": "普通用户",
+                "value": "user"
               },
+
               {
-                "label": "集群只读",
-                "value": "cluster_readonly"
-              },
-              {
-                "label": "平台管理员",
-                "value": "platform_admin"
+                "label": "管理员",
+                "value": "admin"
               }
             ]
           }

--- a/ui/src/components/Sidebar/menu.tsx
+++ b/ui/src/components/Sidebar/menu.tsx
@@ -44,8 +44,13 @@ const items: () => MenuItem[] = () => {
         navigate(path)
     }
     return [
-
-        ...(userRole === 'platform_admin' ? [
+        {
+            label: "代码仓库",
+            icon: <i className="fa-solid fa-code-branch"></i>,
+            key: "repo_management",
+            onClick: () => onMenuClick('/mgm/repo/repo')
+        },
+        ...(userRole === 'admin' ? [
             {
                 label: "平台设置",
                 icon: <i className="fa-solid fa-wrench"></i>,
@@ -88,13 +93,8 @@ const items: () => MenuItem[] = () => {
                         icon: <i className="fa-solid fa-right-to-bracket"></i>,
                         key: "sso_config",
                         onClick: () => onMenuClick('/admin/config/sso_config')
-                    },
-                    {
-                        label: "代码仓库",
-                        icon: <i className="fa-solid fa-code-branch"></i>,
-                        key: "repo_management",
-                        onClick: () => onMenuClick('/admin/repo/repo')
                     }
+
                 ],
             },
         ] : []),

--- a/ui/src/components/ToolBar/index.tsx
+++ b/ui/src/components/ToolBar/index.tsx
@@ -22,10 +22,10 @@ const Toolbar = () => {
         if (token) {
             try {
                 const decoded = jwtDecode<DecodedToken>(token);
-                //role 可能为guest,platform_admin，也可能为guset
+                //role 可能为user,admin，也可能为user
                 setUserInfo({
                     username: decoded.username || '',
-                    role: decoded.role.includes('platform_admin') ? '平台管理员' : '普通用户'
+                    role: decoded.role.includes('admin') ? '管理员' : '普通用户'
                 });
             } catch (error) {
                 console.error('Failed to decode token:', error);


### PR DESCRIPTION
将用户角色和组命名从“平台管理员”和“platform_admin”统一为“管理员”和“admin”，简化角色管理逻辑。同时移除不必要的权限校验中间件和冗余的UI提示信息，提升代码简洁性和可维护性。