### PR TITLE
build: 在 Docker 镜像中添加 git 依赖

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,7 +8,7 @@ FROM alpine:latest
 WORKDIR /app
 COPY --from=builder /app/server /app/server
 RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories \
-    && apk upgrade && apk add --no-cache ca-certificates  \
+    && apk upgrade && apk add --no-cache git tzdata   ca-certificates  \
     && apk del alpine-conf && rm -rf /var/cache/* && chmod +x server
 
 #Server

--- a/backend/Dockerfile.action
+++ b/backend/Dockerfile.action
@@ -11,7 +11,7 @@ ARG TARGETARCH
 COPY backend/bin/${BINARY_NAME}-${TARGETOS}-${TARGETARCH} ${BINARY_NAME}
 
 RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories \
-    && apk upgrade && apk add --no-cache  tzdata   ca-certificates \
+    && apk upgrade && apk add --no-cache git tzdata   ca-certificates \
      && rm -rf /var/cache/* && chmod +x server
 
 EXPOSE 8080


### PR DESCRIPTION
为了支持后端服务中需要 git 功能的操作，在两个 Dockerfile 中均添加了 git 包。
同时优化了包安装命令的格式以保持一致性。