### PR TITLE
feat(task): 实现Pending任务定时自动入队机制

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"log"
 	"os"
@@ -126,6 +127,7 @@ func main() {
 
 	// 启动时清理卡住的任务（超过 10 分钟的运行中任务）
 	cleanupStuckTasks(taskService)
+	taskService.StartPendingTaskScheduler(context.Background(), 10*time.Second)
 
 	// 设置路由
 	r := router.Setup(cfg, repoHandler, taskHandler, docHandler, apiKeyHandler, syncHandler)


### PR DESCRIPTION
## 摘要
- 实现Pending任务定时自动扫描和入队机制
- 当RunAfter依赖满足时，自动将Pending任务入队执行
- 使用后台定时器定期检查待处理的任务

## 变更内容
- 在 `TaskService` 中添加 `StartPendingTaskScheduler` 方法
- 使用 `sync.Once` 确保调度器只启动一次
- 添加 `enqueuePendingTasks` 方法批量处理Pending任务
- 在服务启动时自动启动Pending任务调度器
- 新增单元测试验证批量入队逻辑

## 关键特性
- 定时扫描（默认10秒间隔）Pending状态任务
- 自动检查RunAfter依赖是否满足
- 满足依赖的任务自动入队，不满足的继续等待
- 使用klog.V(6)记录详细调试日志

## 测试计划
- [x] 单元测试覆盖批量入队场景
- [x] 验证依赖满足时入队，不满足时跳过

🤖 Generated with [CodeBuddy Code]