### PR TITLE
fix(sync): 修改TaskUsage使用自动递增ID

### DIFF
--- a/backend/internal/service/sync/service.go
+++ b/backend/internal/service/sync/service.go
@@ -1207,7 +1207,7 @@ func (s *Service) createRemoteTaskUsages(ctx context.Context, targetServer strin
 	items := make([]syncdto.TaskUsageCreateItem, 0, len(usages))
 	for _, usage := range usages {
 		items = append(items, syncdto.TaskUsageCreateItem{
-			ID:               usage.ID,
+			ID:               0,
 			TaskID:           remoteTaskID,
 			APIKeyName:       usage.APIKeyName,
 			PromptTokens:     usage.PromptTokens,
@@ -1252,7 +1252,7 @@ func (s *Service) CreateTaskUsage(ctx context.Context, req syncdto.TaskUsageCrea
 				createdAt = time.Now()
 			}
 			usages = append(usages, model.TaskUsage{
-				ID:               item.ID,
+				ID:               0,
 				TaskID:           taskID,
 				APIKeyName:       item.APIKeyName,
 				PromptTokens:     item.PromptTokens,


### PR DESCRIPTION
## 概述
- 修改TaskUsage创建逻辑，使用数据库自动递增ID而非手动指定ID
- 更新mock仓储以支持自动ID生成
- 更新测试用例以反映新的ID生成行为

## 变更内容
- `backend/internal/service/sync/service.go`:
  - 在`createRemoteTaskUsages`中将TaskUsage的ID设置为0
  - 在`CreateTaskUsage`中将TaskUsage的ID设置为0
- `backend/internal/service/sync/service_test.go`:
  - 在mockTaskUsageRepo中添加nextID字段
  - 在Create、Upsert、UpsertMany方法中实现自动ID生成逻辑
  - 更新测试用例中的ID值

## 测试计划
- [x] 单元测试已通过
- [x] 代码可正常编译


🤖 Generated with [CodeBuddy Code]